### PR TITLE
Fix BLE spam deduplication by rotating random MACs via NimBLE

### DIFF
--- a/src/ble_spam.cpp
+++ b/src/ble_spam.cpp
@@ -152,8 +152,8 @@ const int appleDevicesCount = sizeof(appleDevices) / sizeof(appleDevices[0]);
 void generateRandomMac(uint8_t *mac) {
     for (int i = 0; i < 6; i++) {
         mac[i] = random(256);
-        if (i == 0) { mac[i] |= 0xF0; }
     }
+    mac[5] |= 0xC0;
 }
 
 BLEAdvertisementData GetUniversalAdvertisementData(EBLEPayloadType Type) {
@@ -227,24 +227,26 @@ BLEAdvertisementData GetUniversalAdvertisementData(EBLEPayloadType Type) {
 }
 
 void executeSpam(EBLEPayloadType type) {
-    uint8_t macAddr[6];
-    generateRandomMac(macAddr);
-    esp_base_mac_addr_set(macAddr);
-
     BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
     if (!pAdvertising) {
         return;
     }
 
-    esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, MAX_TX_POWER);
-    BLEAdvertisementData advertisementData = GetUniversalAdvertisementData(type);
-    BLEAdvertisementData oScanResponseData = BLEAdvertisementData();
-
     if (pAdvertising->isAdvertising()) {
         pAdvertising->stop();
     }
 
+    uint8_t macAddr[6];
+    generateRandomMac(macAddr);
+    
+    NimBLEDevice::setOwnAddr(macAddr);
+
+    esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, MAX_TX_POWER);
+    BLEAdvertisementData advertisementData = GetUniversalAdvertisementData(type);
+    BLEAdvertisementData oScanResponseData = BLEAdvertisementData();
+
     pAdvertising->setAdvertisementData(advertisementData);
     pAdvertising->setScanResponseData(oScanResponseData);
+    
     pAdvertising->start();
 }

--- a/src/bluetooth.cpp
+++ b/src/bluetooth.cpp
@@ -1,16 +1,19 @@
 #include "display.h"
 #include <GyverButton.h>
 #include "CONFIG.h"
+#include "menu/bluetooth.h"
+#include "ble_spam.h"
+#include "menu/subghz.h"
 #include <SD.h>
 #include "Explorer.h"
-#include "interface.h"
 #include <NimBLEDevice.h>
 #include <NimBLEHIDDevice.h>
 #include <NimBLEServer.h>
 #include <NimBLEAdvertising.h>
-#include "menu/bluetooth.h"
-#include "ble_spam.h"
-#include "menu/subghz.h"
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <math.h>
 
 extern DisplayType display;
 extern GButton buttonUp;
@@ -359,6 +362,7 @@ static void ensureBleHidInited(BLEHidMode mode) {
   gHid->setHidInfo(0x00, 0x01);
   gHid->setReportMap((uint8_t*)compositeHidReportDescriptor, sizeof(compositeHidReportDescriptor));
   gHid->setBatteryLevel(100);
+  gHid->startServices();
 
   gAdv = NimBLEDevice::getAdvertising();
   NimBLEAdvertisementData advData;
@@ -995,10 +999,6 @@ void handleBluetoothSubmenu() {
       }
       if (buttonOK.isClick()) {
         if (bluetoothMenuIndex == 3) {
-          if (!ensureSDReadyInteractive(true)) {
-            displayBluetoothMenu(display, bluetoothMenuIndex);
-            return;
-          }
           inBadBLE = true;
           inMouseMenu = false;
           explorerLoaded = false;
@@ -1047,6 +1047,7 @@ void handleBluetoothSubmenu() {
             stopBLE();
           }
           BLEDevice::init(bleDeviceName);
+          BLEDevice::setOwnAddrType(BLE_OWN_ADDR_RANDOM);
           lastSpamTime = 0;
           deviceIndex = 0;
           clearBLESpamLog();

--- a/src/bluetooth.cpp
+++ b/src/bluetooth.cpp
@@ -1,19 +1,16 @@
 #include "display.h"
 #include <GyverButton.h>
 #include "CONFIG.h"
-#include "menu/bluetooth.h"
-#include "ble_spam.h"
-#include "menu/subghz.h"
 #include <SD.h>
 #include "Explorer.h"
+#include "interface.h"
 #include <NimBLEDevice.h>
 #include <NimBLEHIDDevice.h>
 #include <NimBLEServer.h>
 #include <NimBLEAdvertising.h>
-#include <vector>
-#include <string>
-#include <algorithm>
-#include <math.h>
+#include "menu/bluetooth.h"
+#include "ble_spam.h"
+#include "menu/subghz.h"
 
 extern DisplayType display;
 extern GButton buttonUp;
@@ -362,7 +359,6 @@ static void ensureBleHidInited(BLEHidMode mode) {
   gHid->setHidInfo(0x00, 0x01);
   gHid->setReportMap((uint8_t*)compositeHidReportDescriptor, sizeof(compositeHidReportDescriptor));
   gHid->setBatteryLevel(100);
-  gHid->startServices();
 
   gAdv = NimBLEDevice::getAdvertising();
   NimBLEAdvertisementData advData;
@@ -999,6 +995,10 @@ void handleBluetoothSubmenu() {
       }
       if (buttonOK.isClick()) {
         if (bluetoothMenuIndex == 3) {
+          if (!ensureSDReadyInteractive(true)) {
+            displayBluetoothMenu(display, bluetoothMenuIndex);
+            return;
+          }
           inBadBLE = true;
           inMouseMenu = false;
           explorerLoaded = false;


### PR DESCRIPTION
Popups were only appearing once because the MAC address wasn't actually rotating within the NimBLE stack, causing devices to deduplicate the packets.
Changes:
- Switched to NimBLEDevice::setOwnAddr() so the stack recognizes the change mid-run.
- Set address type to RANDOM to bypass OS-level device caching.
- Added a stop/start sequence to force the controller to broadcast the new identity on every loop.